### PR TITLE
Avoid triggering this `jira-description-action` on `pr synchronize`

### DIFF
--- a/.github/workflows/jira-description-action.yml
+++ b/.github/workflows/jira-description-action.yml
@@ -1,7 +1,7 @@
 name: jira-description-action
 on:
   pull_request:
-    types: [opened, edited, synchronize]
+    types: [opened, edited]
 jobs:
   add-jira-description:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Avoid triggering this action on  `pr synchronize` as it doesn't affect the PR title or description

This causes an error with the autoupdate action on platform-app never completes this task
<img width="948" alt="Screenshot 2023-05-11 at 11 07 55 AM" src="https://github.com/melio/github-workflows/assets/874904/9677ca51-2451-4de4-b027-df2a04af64c1">
